### PR TITLE
Fix logging middleware header field

### DIFF
--- a/src/server/middlewares/loggingMiddleware.js
+++ b/src/server/middlewares/loggingMiddleware.js
@@ -1,20 +1,21 @@
 const loggingMiddleware = (db) =>
-    (req, res, next) => {
-        const ip = (req.headers['x-forwarded-for'] || req.connection.remoteAddress || '').split(',')[0].trim();
-        const headers = JSON.stringify(req.headers);
-        const originalUrl = req.originalUrl;
-        // Persist this info on DB
-        console.log('ip: ', ip)
-        console.log('headers: ', headers)
-        console.log('originalUrl: ', originalUrl)
-        const data = db.logging.create({
-            ip:ip,
-            headers:headers,
-            action:originalUrl
+  async (req, res, next) => {
+    const ip = (req.headers['x-forwarded-for'] || req.connection.remoteAddress || '').split(',')[0].trim();
+    const header = JSON.stringify(req.headers);
+    const originalUrl = req.originalUrl;
 
-        })
-        console.log('dataaaa: ', data)       
-        next();
+    try {
+      await db.logging.create({
+        ip,
+        header,
+        action: originalUrl,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Error saving log:', err);
     }
+
+    next();
+  };
 
 module.exports = loggingMiddleware;


### PR DESCRIPTION
## Summary
- fix property name in logging middleware
- persist logs asynchronously and handle failures

## Testing
- `node -e "require('./src/server/middlewares/loggingMiddleware.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68449219d130832a9a6a3658ba941ec7